### PR TITLE
It seems like nant does not support ".net framework 4.6.1" now. #55

### DIFF
--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -24,7 +24,25 @@ DEFINE = $(DEFINE),NET_3_5,ONLY_3_5
 !else if "$(TARGET)" == "net-4.0" || "$(TARGET)" == "mono-4.0"
 DEFINE = $(DEFINE),NET_3_5,NET_4_0,ONLY_4_0
 !else if "$(TARGET)" == "net-4.5" || "$(TARGET)" == "mono-4.5"
-DEFINE = $(DEFINE),NET_3_5,NET_4_0,NET_4_5,ONLY_4_5
+DEFINE = $(DEFINE),NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x
+!else if "$(TARGET)" == "net-4.5.1"
+DEFINE = $(DEFINE),NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x
+!else if "$(TARGET)" == "net-4.5.2"
+DEFINE = $(DEFINE),NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x
+!else if "$(TARGET)" == "net-4.6"
+DEFINE = $(DEFINE),NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x,NET_4_6,ONLY_4_6_x
+!else if "$(TARGET)" == "net-4.6.1"
+DEFINE = $(DEFINE),NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x,NET_4_6,ONLY_4_6_x
+!else if "$(TARGET)" == "net-4.6.2"
+DEFINE = $(DEFINE),NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x,NET_4_6,ONLY_4_6_x
+!else if "$(TARGET)" == "net-4.7"
+DEFINE = $(DEFINE),NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x,NET_4_6,ONLY_4_6_x,NET_4_7,ONLY_NET_4_7_x
+!else if "$(TARGET)" == "net-4.7.1"
+DEFINE = $(DEFINE),NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x,NET_4_6,ONLY_4_6_x,NET_4_7,ONLY_NET_4_7_x
+!else if "$(TARGET)" == "net-4.7.2"
+DEFINE = $(DEFINE),NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x,NET_4_6,ONLY_4_6_x,NET_4_7,ONLY_NET_4_7_x
+!else if "$(TARGET)" == "net-4.8"
+DEFINE = $(DEFINE),NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x,NET_4_6,ONLY_4_6_x,NET_4_7,ONLY_NET_4_7_x,NET_4_8,ONLY_NET_4_8
 !else
 !error Specified target "$(TARGET)" is not valid
 !endif

--- a/NAnt.build
+++ b/NAnt.build
@@ -781,6 +781,7 @@
     </target>
     <!-- Framework support targets -->
     <target name="set-framework-configuration">
+        <echo>${framework::get-target-framework()}</echo>
         <if test="${not(target::exists('set-'+framework::get-target-framework()+'-framework-configuration'))}">
             <fail message="The '${framework::get-target-framework()}' framework is not supported by this version of NAnt." />
         </if>
@@ -806,7 +807,61 @@
     </target>
     <target name="set-net-4.5-framework-configuration">
         <property name="nant.settings.currentframework" value="net-4.5" />
-        <property name="current.build.defines" value="${build.defines}NET,NET_1_0,NET_1_1,NET_2_0,NET_3_5,NET_4_0,NET_4_5,ONLY_4_5" dynamic="true" />
+        <property name="current.build.defines" value="${build.defines}NET,NET_1_0,NET_1_1,NET_2_0,NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x" dynamic="true" />
+        <property name="link.sdkdoc.version" value="SDK_v1_1" />
+        <property name="link.sdkdoc.web" value="true" />
+    </target>
+    <target name="set-net-4.5.1-framework-configuration">
+        <property name="nant.settings.currentframework" value="net-4.5.1" />
+        <property name="current.build.defines" value="${build.defines}NET,NET_1_0,NET_1_1,NET_2_0,NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x" dynamic="true" />
+        <property name="link.sdkdoc.version" value="SDK_v1_1" />
+        <property name="link.sdkdoc.web" value="true" />
+    </target>
+    <target name="set-net-4.5.2-framework-configuration">
+        <property name="nant.settings.currentframework" value="net-4.5.2" />
+        <property name="current.build.defines" value="${build.defines}NET,NET_1_0,NET_1_1,NET_2_0,NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x" dynamic="true" />
+        <property name="link.sdkdoc.version" value="SDK_v1_1" />
+        <property name="link.sdkdoc.web" value="true" />
+    </target>
+    <target name="set-net-4.6-framework-configuration">
+        <property name="nant.settings.currentframework" value="net-4.6" />
+        <property name="current.build.defines" value="${build.defines}NET,NET_1_0,NET_1_1,NET_2_0,NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x,NET_4_6,ONLY_4_6_x" dynamic="true" />
+        <property name="link.sdkdoc.version" value="SDK_v1_1" />
+        <property name="link.sdkdoc.web" value="true" />
+    </target>
+    <target name="set-net-4.6.1-framework-configuration">
+        <property name="nant.settings.currentframework" value="net-4.6.1" />
+        <property name="current.build.defines" value="${build.defines}NET,NET_1_0,NET_1_1,NET_2_0,NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x,NET_4_6,ONLY_4_6_x" dynamic="true" />
+        <property name="link.sdkdoc.version" value="SDK_v1_1" />
+        <property name="link.sdkdoc.web" value="true" />
+    </target>
+    <target name="set-net-4.6.2-framework-configuration">
+        <property name="nant.settings.currentframework" value="net-4.6.2" />
+        <property name="current.build.defines" value="${build.defines}NET,NET_1_0,NET_1_1,NET_2_0,NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x,NET_4_6,ONLY_4_6_x" dynamic="true" />
+        <property name="link.sdkdoc.version" value="SDK_v1_1" />
+        <property name="link.sdkdoc.web" value="true" />
+    </target>
+    <target name="set-net-4.7-framework-configuration">
+        <property name="nant.settings.currentframework" value="net-4.7" />
+        <property name="current.build.defines" value="${build.defines}NET,NET_1_0,NET_1_1,NET_2_0,NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x,NET_4_6,ONLY_4_6_x,NET_4_7,ONLY_NET_4_7_x" dynamic="true" />
+        <property name="link.sdkdoc.version" value="SDK_v1_1" />
+        <property name="link.sdkdoc.web" value="true" />
+    </target>
+    <target name="set-net-4.7.1-framework-configuration">
+        <property name="nant.settings.currentframework" value="net-4.7.1" />
+        <property name="current.build.defines" value="${build.defines}NET,NET_1_0,NET_1_1,NET_2_0,NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x,NET_4_6,ONLY_4_6_x,NET_4_7,ONLY_NET_4_7_x" dynamic="true" />
+        <property name="link.sdkdoc.version" value="SDK_v1_1" />
+        <property name="link.sdkdoc.web" value="true" />
+    </target>
+    <target name="set-net-4.7.2-framework-configuration">
+        <property name="nant.settings.currentframework" value="net-4.7.2" />
+        <property name="current.build.defines" value="${build.defines}NET,NET_1_0,NET_1_1,NET_2_0,NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x,NET_4_6,ONLY_4_6_x,NET_4_7,ONLY_NET_4_7_x" dynamic="true" />
+        <property name="link.sdkdoc.version" value="SDK_v1_1" />
+        <property name="link.sdkdoc.web" value="true" />
+    </target>
+    <target name="set-net-4.8-framework-configuration">
+        <property name="nant.settings.currentframework" value="net-4.8" />
+        <property name="current.build.defines" value="${build.defines}NET,NET_1_0,NET_1_1,NET_2_0,NET_3_5,NET_4_0,NET_4_5,ONLY_4_5_x,NET_4_6,ONLY_4_6_x,NET_4_7,ONLY_NET_4_7_x,NET_4_8,ONLY_NET_4_8" dynamic="true" />
         <property name="link.sdkdoc.version" value="SDK_v1_1" />
         <property name="link.sdkdoc.web" value="true" />
     </target>

--- a/src/NAnt.Console/App.config
+++ b/src/NAnt.Console/App.config
@@ -34,6 +34,7 @@
                         <!-- exclude Microsoft.NET specific test assembly -->
                         <exclude name="NAnt.MSNet.Tests.dll" />
                 </task-assemblies>
+                <!-- deprecated -->
                 <framework 
                     name="net-1.0"
                     family="net"
@@ -136,6 +137,7 @@
                         </task>
                     </tasks>
                 </framework>
+                <!-- deprecated -->
                 <framework 
                     name="net-1.1"
                     family="net"
@@ -236,6 +238,7 @@
                         </task>
                     </tasks>
                 </framework>
+                <!-- deprecated -->
                 <framework 
                     name="net-2.0"
                     family="net"
@@ -899,19 +902,21 @@
                     version="4.5"
                     description="Microsoft .NET Framework 4.5"
                     sdkdirectory="${sdkInstallRoot}"
-                    frameworkdirectory="${path::combine(installRoot, 'v4.0.30319')}"
-                    frameworkassemblydirectory="${path::combine(installRoot, 'v4.0.30319')}"
+                    frameworkdirectory="${installRoot}"
+                    frameworkassemblydirectory="${installRoot}"
                     clrversion="4.0.30319"
                     clrtype="Desktop"
                     vendor="Microsoft"
                     >
                     <runtime>
                         <probing-paths>
-                            <directory name="lib/common/2.0" />
                             <directory name="lib/common/neutral" />
+                            <directory name="lib/net/neutral" />
+                            <directory name="lib/common/2.0" />
                             <directory name="lib/common/4.0" />
                             <directory name="lib/net/4.0" />
-                            <directory name="lib/net/neutral" />
+                            <directory name="lib/common/4.5" />
+                            <directory name="lib/net/4.5" />
                         </probing-paths>
                         <modes>
                             <strict>
@@ -921,7 +926,7 @@
                             </strict>
                         </modes>
                     </runtime>
-                    <reference-assemblies basedir="${path::combine(installRoot, 'v4.0.30319')}">
+                    <reference-assemblies basedir="${installRoot}">
                         <include name="Accessibility.dll" />
                         <include name="Microsoft.Build.Conversion.v4.0.dll" />
                         <include name="Microsoft.Build.dll" />
@@ -1027,7 +1032,7 @@
                         <include name="System.Xml.Linq.dll" />
                     </reference-assemblies>
                     <!-- WPF Assemblies -->
-                    <reference-assemblies basedir="${path::combine(installRoot, 'v4.0.30319')}/WPF">
+                    <reference-assemblies basedir="${path::combine(installRoot, 'WPF')}">
                         <include name="NaturalLanguage6.dll" />
                         <include name="NlsData0009.dll" />
                         <include name="NlsLexicons0009.dll" />
@@ -1169,22 +1174,26 @@
                         <include name="extensions/net/neutral/**/*.dll" />
                         <!-- include MS.NET 4.0 specific assemblies -->
                         <include name="extensions/net/4.0/**/*.dll" />
+                        <!-- include MS.NET 4.5 specific assemblies -->
+                        <include name="extensions/net/4.5/**/*.dll" />
                         <!-- include MS.NET specific task assembly -->
                         <include name="NAnt.MSNetTasks.dll" />
                         <!-- include MS.NET specific test assembly -->
                         <include name="NAnt.MSNet.Tests.dll" />
                         <!-- include .NET 4.0 specific assemblies -->
                         <include name="extensions/common/4.0/**/*.dll" />
+                        <!-- include .NET 4.5 specific assemblies -->
+                        <include name="extensions/common/4.5/**/*.dll" />
                     </task-assemblies>
                     <tool-paths>
                         <directory name="${sdkInstallRoot}"
                             if="${property::exists('sdkInstallRoot')}" />
-                        <directory name="${path::combine(installRoot, 'v4.0.30319')}" />
+                        <directory name="${installRoot}" />
                     </tool-paths>
                     <project>
                         <readregistry
                             property="installRoot"
-                            key="SOFTWARE\Microsoft\.NETFramework\InstallRoot"
+                            key="SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\InstallPath"
                             hive="LocalMachine" />
                         <locatesdk property="sdkInstallRoot" minwinsdkver="v8.0" minnetfxver="4.0" maxnetfxver="4.0.99999" failonerror="false" />
                     </project>
@@ -1230,6 +1239,2916 @@
                         </task>
                     </tasks>
                 </framework>
+                <framework 
+                    name="net-4.5.1"
+                    family="net"
+                    version="4.5.1"
+                    description="Microsoft .NET Framework 4.5.1"
+                    sdkdirectory="${sdkInstallRoot}"
+                    frameworkdirectory="${installRoot}"
+                    frameworkassemblydirectory="${installRoot}"
+                    clrversion="4.0.30319"
+                    clrtype="Desktop"
+                    vendor="Microsoft"
+                    >
+                    <runtime>
+                        <probing-paths>
+                            <directory name="lib/common/neutral" />
+                            <directory name="lib/net/neutral" />
+                            <directory name="lib/common/2.0" />
+                            <directory name="lib/common/4.0" />
+                            <directory name="lib/net/4.0" />
+                            <directory name="lib/common/4.5" />
+                            <directory name="lib/net/4.5" />
+                        </probing-paths>
+                        <modes>
+                            <strict>
+                                <environment>
+                                    <variable name="COMPLUS_VERSION" value="v4.0.30319" />
+                                </environment>
+                            </strict>
+                        </modes>
+                    </runtime>
+                    <reference-assemblies basedir="${installRoot}">
+                        <include name="Accessibility.dll" />
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.Data.Entity.Build.Tasks.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.Transactions.Bridge.dll" />
+                        <include name="Microsoft.Transactions.Bridge.Dtc.dll" />
+                        <include name="Microsoft.VisualBasic.Activities.Compiler.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Configuration.Install.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtensions.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.Dynamic.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.ServiceMoniker40.dll" />
+                        <include name="System.ServiceModel.WasHosting.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xaml.Hosting.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <!-- WPF Assemblies -->
+                    <reference-assemblies basedir="${path::combine(installRoot, 'WPF')}">
+                        <include name="NaturalLanguage6.dll" />
+                        <include name="NlsData0009.dll" />
+                        <include name="NlsLexicons0009.dll" />
+                        <include name="PenIMC.dll" />
+                        <include name="PresentationCore.dll" />
+                        <include name="PresentationFramework.Aero.dll" />
+                        <include name="PresentationFramework.Classic.dll" />
+                        <include name="PresentationFramework.dll" />
+                        <include name="PresentationFramework.Luna.dll" />
+                        <include name="PresentationFramework.Royale.dll" />
+                        <include name="PresentationHost_v0400.dll" />
+                        <include name="PresentationNative_v0400.dll" />
+                        <include name="PresentationUI.dll" />
+                        <include name="ReachFramework.dll" />
+                        <include name="System.Printing.dll" />
+                        <include name="System.Speech.dll" />
+                        <include name="System.Windows.Input.Manipulations.dll" />
+                        <include name="System.Windows.Presentation.dll" />
+                        <include name="UIAutomationClient.dll" />
+                        <include name="UIAutomationClientsideProviders.dll" />
+                        <include name="UIAutomationProvider.dll" />
+                        <include name="UIAutomationTypes.dll" />
+                        <include name="WindowsBase.dll" />
+                        <include name="WindowsFormsIntegration.dll" />
+                        <include name="wpfgfx_v0400.dll" />
+                        <include name="wpftxt_v0400.dll" />
+                    </reference-assemblies>
+                    <reference-assemblies basedir="${environment::get-folder-path('ProgramFiles')}/Reference Assemblies/Microsoft/Framework/.NETFramework/v4.5">
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Comptatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="PresentationBuildTasks.dll" />
+                        <include name="PresentationCore.dll" />
+                        <include name="WindowsBase.dll" />
+                        <include name="PresentationFramework.dll" />
+                        <include name="PresentationFramework.Aero.dll" />
+                        <include name="PresentationFramework.Classic.dll" />
+                        <include name="PresentationFramework.Luna.dll" />
+                        <include name="PresentationFramework.Royale.dll" />
+                        <include name="ReachFramework.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract.dll" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtension.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.AccountManagement.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Printing.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Speech.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Windows.Input.Manipulations.dll" />
+                        <include name="System.Windows.Presentation.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <task-assemblies>
+                        <!-- include MS.NET version-neutral assemblies -->
+                        <include name="extensions/net/neutral/**/*.dll" />
+                        <!-- include MS.NET 4.0 specific assemblies -->
+                        <include name="extensions/net/4.0/**/*.dll" />
+                        <!-- include MS.NET 4.5 specific assemblies -->
+                        <include name="extensions/net/4.5/**/*.dll" />
+                        <!-- include MS.NET specific task assembly -->
+                        <include name="NAnt.MSNetTasks.dll" />
+                        <!-- include MS.NET specific test assembly -->
+                        <include name="NAnt.MSNet.Tests.dll" />
+                        <!-- include .NET 4.0 specific assemblies -->
+                        <include name="extensions/common/4.0/**/*.dll" />
+                        <!-- include .NET 4.5 specific assemblies -->
+                        <include name="extensions/common/4.5/**/*.dll" />
+                    </task-assemblies>
+                    <tool-paths>
+                        <directory name="${sdkInstallRoot}"
+                            if="${property::exists('sdkInstallRoot')}" />
+                        <directory name="${installRoot}" />
+                    </tool-paths>
+                    <project>
+                        <readregistry
+                            property="installRoot"
+                            key="SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\InstallPath"
+                            hive="LocalMachine" />
+                        <locatesdk property="sdkInstallRoot" minwinsdkver="v8.1" minnetfxver="4.0" maxnetfxver="4.0.99999" failonerror="false" />
+                    </project>
+                    <tasks>
+                        <task name="csc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportslangversion">true</attribute>
+                        </task>
+                        <task name="vbc">
+                            <attribute name="supportsdocgeneration">true</attribute>
+                            <attribute name="supportsnostdlib">true</attribute>
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                        </task>
+                        <task name="jsc">
+                            <attribute name="supportsplatform">true</attribute>
+                        </task>
+                        <task name="vjc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                        </task>
+                        <task name="resgen">
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                            <attribute name="supportsexternalfilereferences">true</attribute>
+                        </task>
+                        <task name="delay-sign">
+                            <attribute name="exename">sn</attribute>
+                        </task>
+                        <task name="license">
+                            <attribute name="exename">lc</attribute>
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                        </task>
+                    </tasks>
+                </framework>
+                <framework 
+                    name="net-4.5.2"
+                    family="net"
+                    version="4.5.2"
+                    description="Microsoft .NET Framework 4.5.2"
+                    sdkdirectory="${sdkInstallRoot}"
+                    frameworkdirectory="${installRoot}"
+                    frameworkassemblydirectory="${installRoot}"
+                    clrversion="4.0.30319"
+                    clrtype="Desktop"
+                    vendor="Microsoft"
+                    >
+                    <runtime>
+                        <probing-paths>
+                            <directory name="lib/common/neutral" />
+                            <directory name="lib/net/neutral" />
+                            <directory name="lib/common/2.0" />
+                            <directory name="lib/common/4.0" />
+                            <directory name="lib/net/4.0" />
+                            <directory name="lib/common/4.5" />
+                            <directory name="lib/net/4.5" />
+                        </probing-paths>
+                        <modes>
+                            <strict>
+                                <environment>
+                                    <variable name="COMPLUS_VERSION" value="v4.0.30319" />
+                                </environment>
+                            </strict>
+                        </modes>
+                    </runtime>
+                    <reference-assemblies basedir="${installRoot}">
+                        <include name="Accessibility.dll" />
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.Data.Entity.Build.Tasks.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.Transactions.Bridge.dll" />
+                        <include name="Microsoft.Transactions.Bridge.Dtc.dll" />
+                        <include name="Microsoft.VisualBasic.Activities.Compiler.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Configuration.Install.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtensions.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.Dynamic.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.ServiceMoniker40.dll" />
+                        <include name="System.ServiceModel.WasHosting.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xaml.Hosting.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <!-- WPF Assemblies -->
+                    <reference-assemblies basedir="${path::combine(installRoot, 'WPF')}">
+                        <include name="NaturalLanguage6.dll" />
+                        <include name="NlsData0009.dll" />
+                        <include name="NlsLexicons0009.dll" />
+                        <include name="PenIMC.dll" />
+                        <include name="PresentationCore.dll" />
+                        <include name="PresentationFramework.Aero.dll" />
+                        <include name="PresentationFramework.Classic.dll" />
+                        <include name="PresentationFramework.dll" />
+                        <include name="PresentationFramework.Luna.dll" />
+                        <include name="PresentationFramework.Royale.dll" />
+                        <include name="PresentationHost_v0400.dll" />
+                        <include name="PresentationNative_v0400.dll" />
+                        <include name="PresentationUI.dll" />
+                        <include name="ReachFramework.dll" />
+                        <include name="System.Printing.dll" />
+                        <include name="System.Speech.dll" />
+                        <include name="System.Windows.Input.Manipulations.dll" />
+                        <include name="System.Windows.Presentation.dll" />
+                        <include name="UIAutomationClient.dll" />
+                        <include name="UIAutomationClientsideProviders.dll" />
+                        <include name="UIAutomationProvider.dll" />
+                        <include name="UIAutomationTypes.dll" />
+                        <include name="WindowsBase.dll" />
+                        <include name="WindowsFormsIntegration.dll" />
+                        <include name="wpfgfx_v0400.dll" />
+                        <include name="wpftxt_v0400.dll" />
+                    </reference-assemblies>
+                    <reference-assemblies basedir="${environment::get-folder-path('ProgramFiles')}/Reference Assemblies/Microsoft/Framework/.NETFramework/v4.5.2">
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Comptatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="PresentationBuildTasks.dll" />
+                        <include name="PresentationCore.dll" />
+                        <include name="WindowsBase.dll" />
+                        <include name="PresentationFramework.dll" />
+                        <include name="PresentationFramework.Aero.dll" />
+                        <include name="PresentationFramework.Classic.dll" />
+                        <include name="PresentationFramework.Luna.dll" />
+                        <include name="PresentationFramework.Royale.dll" />
+                        <include name="ReachFramework.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract.dll" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtension.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.AccountManagement.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Printing.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Speech.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Windows.Input.Manipulations.dll" />
+                        <include name="System.Windows.Presentation.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <task-assemblies>
+                        <!-- include MS.NET version-neutral assemblies -->
+                        <include name="extensions/net/neutral/**/*.dll" />
+                        <!-- include MS.NET 4.0 specific assemblies -->
+                        <include name="extensions/net/4.0/**/*.dll" />
+                        <!-- include MS.NET 4.5 specific assemblies -->
+                        <include name="extensions/net/4.5/**/*.dll" />
+                        <!-- include MS.NET specific task assembly -->
+                        <include name="NAnt.MSNetTasks.dll" />
+                        <!-- include MS.NET specific test assembly -->
+                        <include name="NAnt.MSNet.Tests.dll" />
+                        <!-- include .NET 4.0 specific assemblies -->
+                        <include name="extensions/common/4.0/**/*.dll" />
+                        <!-- include .NET 4.5 specific assemblies -->
+                        <include name="extensions/common/4.5/**/*.dll" />
+                    </task-assemblies>
+                    <tool-paths>
+                        <directory name="${sdkInstallRoot}"
+                            if="${property::exists('sdkInstallRoot')}" />
+                        <directory name="${installRoot}" />
+                    </tool-paths>
+                    <project>
+                        <readregistry
+                            property="installRoot"
+                            key="SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\InstallPath"
+                            hive="LocalMachine" />
+                        <locatesdk property="sdkInstallRoot" minwinsdkver="v8.1" minnetfxver="4.0" maxnetfxver="4.0.99999" failonerror="false" />
+                    </project>
+                    <tasks>
+                        <task name="csc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportslangversion">true</attribute>
+                        </task>
+                        <task name="vbc">
+                            <attribute name="supportsdocgeneration">true</attribute>
+                            <attribute name="supportsnostdlib">true</attribute>
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                        </task>
+                        <task name="jsc">
+                            <attribute name="supportsplatform">true</attribute>
+                        </task>
+                        <task name="vjc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                        </task>
+                        <task name="resgen">
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                            <attribute name="supportsexternalfilereferences">true</attribute>
+                        </task>
+                        <task name="delay-sign">
+                            <attribute name="exename">sn</attribute>
+                        </task>
+                        <task name="license">
+                            <attribute name="exename">lc</attribute>
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                        </task>
+                    </tasks>
+                </framework>
+                <framework 
+                    name="net-4.6"
+                    family="net"
+                    version="4.6"
+                    description="Microsoft .NET Framework 4.6"
+                    sdkdirectory="${sdkInstallRoot}"
+                    frameworkdirectory="${installRoot}"
+                    frameworkassemblydirectory="${installRoot}"
+                    clrversion="4.0.30319"
+                    clrtype="Desktop"
+                    vendor="Microsoft"
+                    >
+                    <runtime>
+                        <probing-paths>
+                            <directory name="lib/common/2.0" />
+                            <directory name="lib/common/neutral" />
+                            <directory name="lib/common/4.0" />
+                            <directory name="lib/common/4.5" />
+                            <directory name="lib/common/4.6" />
+                        </probing-paths>
+                        <modes>
+                            <strict>
+                                <environment>
+                                    <variable name="COMPLUS_VERSION" value="v4.6" />
+                                </environment>
+                            </strict>
+                        </modes>
+                    </runtime>
+                    <reference-assemblies basedir="${installRoot}">
+                        <include name="Accessibility.dll" />
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.Data.Entity.Build.Tasks.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.Transactions.Bridge.dll" />
+                        <include name="Microsoft.Transactions.Bridge.Dtc.dll" />
+                        <include name="Microsoft.VisualBasic.Activities.Compiler.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Configuration.Install.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtensions.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.Dynamic.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                       <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.ServiceMoniker40.dll" />
+                        <include name="System.ServiceModel.WasHosting.dll" />
+                       <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xaml.Hosting.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <reference-assemblies basedir="${environment::get-folder-path('ProgramFiles')}/Reference Assemblies/Microsoft/Framework/.NETFramework/v4.6">
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Comptatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="PresentationBuildTasks.dll" />
+                        <include name="PresentationCore.dll" />
+                        <include name="PresentationFramework.Aero.dll" />
+                        <include name="PresentationFramework.Classic.dll" />
+                        <include name="PresentationFramework.Luna.dll" />
+                        <include name="PresentationFramework.Royale.dll" />
+                        <include name="ReachFramework.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract.dll" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Core.dll" />
+                       <include name="System.Data.DataSetExtension.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.AccountManagement.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Printing.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Speech.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Windows.Input.Manipulations.dll" />
+                        <include name="System.Windows.Presentation.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <task-assemblies>
+                        <!-- include MS.NET version-neutral assemblies -->
+                        <include name="extensions/net/neutral/**/*.dll" />
+                        <!-- include MS.NET 4.0 specific assemblies -->
+                        <include name="extensions/net/4.0/**/*.dll" />
+                        <!-- include MS.NET 4.5 specific assemblies -->
+                        <include name="extensions/net/4.5/**/*.dll" />
+                        <!-- include MS.NET 4.6 specific assemblies -->
+                        <include name="extensions/net/4.6/**/*.dll" />
+                        <!-- include MS.NET specific task assembly -->
+                        <include name="NAnt.MSNetTasks.dll" />
+                        <!-- include MS.NET specific test assembly -->
+                        <include name="NAnt.MSNet.Tests.dll" />
+                        <!-- include .NET 4.0 specific assemblies -->
+                        <include name="extensions/common/4.0/**/*.dll" />
+                        <!-- include .NET 4.5 specific assemblies -->
+                        <include name="extensions/common/4.5/**/*.dll" />
+                        <!-- include .NET 4.6 specific assemblies -->
+                        <include name="extensions/common/4.6/**/*.dll" />
+                    </task-assemblies>
+                    <tool-paths>
+                        <directory name="${sdkInstallRoot}"
+                            if="${property::exists('sdkInstallRoot')}" />
+                        <directory name="${installRoot}" />
+                    </tool-paths>
+                    <project>
+                        <readregistry
+                            property="installRoot"
+                            key="SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\InstallPath"
+                            hive="LocalMachine" />
+                        <locatesdk property="sdkInstallRoot" minwinsdkver="8.1" minnetfxver="4.0" maxnetfxver="4.0.99999" failonerror="false" />
+                    </project>
+                    <tasks>
+                        <task name="csc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportslangversion">true</attribute>
+                        </task>
+                        <task name="vbc">
+                            <attribute name="supportsdocgeneration">true</attribute>
+                            <attribute name="supportsnostdlib">true</attribute>
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                        </task>
+                        <task name="jsc">
+                            <attribute name="supportsplatform">true</attribute>
+                        </task>
+                        <task name="vjc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                        </task>
+                        <task name="resgen">
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                            <attribute name="supportsexternalfilereferences">true</attribute>
+                       </task>
+                        <task name="delay-sign">
+                            <attribute name="exename">sn</attribute>
+                        </task>
+                        <task name="license">
+                            <attribute name="exename">lc</attribute>
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                        </task>
+                    </tasks>
+                </framework>
+                <framework 
+                    name="net-4.6.1"
+                    family="net"
+                    version="4.6.1"
+                    description="Microsoft .NET Framework 4.6.1"
+                    sdkdirectory="${sdkInstallRoot}"
+                    frameworkdirectory="${installRoot}"
+                    frameworkassemblydirectory="${installRoot}"
+                    clrversion="4.0.30319"
+                    clrtype="Desktop"
+                    vendor="Microsoft"
+                    >
+                    <runtime>
+                        <probing-paths>
+                            <directory name="lib/common/2.0" />
+                            <directory name="lib/common/neutral" />
+                            <directory name="lib/common/4.0" />
+                            <directory name="lib/common/4.5" />
+                            <directory name="lib/common/4.6" />
+                        </probing-paths>
+                        <modes>
+                            <strict>
+                                <environment>
+                                    <variable name="COMPLUS_VERSION" value="v4.6.1" />
+                                </environment>
+                            </strict>
+                        </modes>
+                    </runtime>
+                    <reference-assemblies basedir="${installRoot}">
+                        <include name="Accessibility.dll" />
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.Data.Entity.Build.Tasks.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.Transactions.Bridge.dll" />
+                        <include name="Microsoft.Transactions.Bridge.Dtc.dll" />
+                        <include name="Microsoft.VisualBasic.Activities.Compiler.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Configuration.Install.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtensions.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.Dynamic.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.ServiceMoniker40.dll" />
+                        <include name="System.ServiceModel.WasHosting.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xaml.Hosting.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <reference-assemblies basedir="${environment::get-folder-path('ProgramFiles')}/Reference Assemblies/Microsoft/Framework/.NETFramework/v4.6.1">
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Comptatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="PresentationBuildTasks.dll" />
+                        <include name="PresentationCore.dll" />
+                        <include name="PresentationFramework.Aero.dll" />
+                        <include name="PresentationFramework.Classic.dll" />
+                        <include name="PresentationFramework.Luna.dll" />
+                        <include name="PresentationFramework.Royale.dll" />
+                        <include name="ReachFramework.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract.dll" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Core.dll" />
+                       <include name="System.Data.DataSetExtension.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.AccountManagement.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Printing.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Speech.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Windows.Input.Manipulations.dll" />
+                        <include name="System.Windows.Presentation.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <task-assemblies>
+                        <!-- include MS.NET version-neutral assemblies -->
+                        <include name="extensions/net/neutral/**/*.dll" />
+                        <!-- include MS.NET 4.0 specific assemblies -->
+                        <include name="extensions/net/4.0/**/*.dll" />
+                        <!-- include MS.NET 4.5 specific assemblies -->
+                        <include name="extensions/net/4.5/**/*.dll" />
+                        <!-- include MS.NET 4.6 specific assemblies -->
+                        <include name="extensions/net/4.6/**/*.dll" />
+                        <!-- include MS.NET specific task assembly -->
+                        <include name="NAnt.MSNetTasks.dll" />
+                        <!-- include MS.NET specific test assembly -->
+                        <include name="NAnt.MSNet.Tests.dll" />
+                        <!-- include .NET 4.0 specific assemblies -->
+                        <include name="extensions/common/4.0/**/*.dll" />
+                        <!-- include .NET 4.5 specific assemblies -->
+                        <include name="extensions/common/4.5/**/*.dll" />
+                        <!-- include .NET 4.6 specific assemblies -->
+                        <include name="extensions/common/4.6/**/*.dll" />
+                    </task-assemblies>
+                    <tool-paths>
+                        <directory name="${sdkInstallRoot}"
+                            if="${property::exists('sdkInstallRoot')}" />
+                        <directory name="${installRoot}" />
+                    </tool-paths>
+                    <project>
+                        <readregistry
+                            property="installRoot"
+                            key="SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\InstallPath"
+                            hive="LocalMachine" />
+                        <locatesdk property="sdkInstallRoot" minwinsdkver="10.0" minnetfxver="4.0" maxnetfxver="4.0.99999" failonerror="false" />
+                    </project>
+                    <tasks>
+                        <task name="csc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportslangversion">true</attribute>
+                        </task>
+                        <task name="vbc">
+                            <attribute name="supportsdocgeneration">true</attribute>
+                            <attribute name="supportsnostdlib">true</attribute>
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                        </task>
+                        <task name="jsc">
+                            <attribute name="supportsplatform">true</attribute>
+                        </task>
+                        <task name="vjc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                        </task>
+                        <task name="resgen">
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                            <attribute name="supportsexternalfilereferences">true</attribute>
+                       </task>
+                        <task name="delay-sign">
+                            <attribute name="exename">sn</attribute>
+                        </task>
+                        <task name="license">
+                            <attribute name="exename">lc</attribute>
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                        </task>
+                    </tasks>
+                </framework>
+                <framework 
+                    name="net-4.6.2"
+                    family="net"
+                    version="4.6.2"
+                    description="Microsoft .NET Framework 4.6.2"
+                    sdkdirectory="${sdkInstallRoot}"
+                    frameworkdirectory="${installRoot}"
+                    frameworkassemblydirectory="${installRoot}"
+                    clrversion="4.0.30319"
+                    clrtype="Desktop"
+                    vendor="Microsoft"
+                    >
+                    <runtime>
+                        <probing-paths>
+                            <directory name="lib/common/2.0" />
+                            <directory name="lib/common/neutral" />
+                            <directory name="lib/common/4.0" />
+                            <directory name="lib/common/4.5" />
+                            <directory name="lib/common/4.6" />
+                        </probing-paths>
+                        <modes>
+                            <strict>
+                                <environment>
+                                    <variable name="COMPLUS_VERSION" value="v4.6.2" />
+                                </environment>
+                            </strict>
+                        </modes>
+                    </runtime>
+                    <reference-assemblies basedir="${installRoot}">
+                        <include name="Accessibility.dll" />
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.Data.Entity.Build.Tasks.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.Transactions.Bridge.dll" />
+                        <include name="Microsoft.Transactions.Bridge.Dtc.dll" />
+                        <include name="Microsoft.VisualBasic.Activities.Compiler.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Configuration.Install.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtensions.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.Dynamic.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.ServiceMoniker40.dll" />
+                        <include name="System.ServiceModel.WasHosting.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xaml.Hosting.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <reference-assemblies basedir="${environment::get-folder-path('ProgramFiles')}/Reference Assemblies/Microsoft/Framework/.NETFramework/v4.6.2">
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Comptatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="PresentationBuildTasks.dll" />
+                        <include name="PresentationCore.dll" />
+                        <include name="PresentationFramework.Aero.dll" />
+                        <include name="PresentationFramework.Classic.dll" />
+                        <include name="PresentationFramework.Luna.dll" />
+                        <include name="PresentationFramework.Royale.dll" />
+                        <include name="ReachFramework.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract.dll" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtension.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.AccountManagement.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Printing.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Speech.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Windows.Input.Manipulations.dll" />
+                        <include name="System.Windows.Presentation.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <task-assemblies>
+                        <!-- include MS.NET version-neutral assemblies -->
+                        <include name="extensions/net/neutral/**/*.dll" />
+                        <!-- include MS.NET 4.0 specific assemblies -->
+                        <include name="extensions/net/4.0/**/*.dll" />
+                        <!-- include MS.NET 4.5 specific assemblies -->
+                        <include name="extensions/net/4.5/**/*.dll" />
+                        <!-- include MS.NET 4.6 specific assemblies -->
+                        <include name="extensions/net/4.6/**/*.dll" />
+                        <!-- include MS.NET specific task assembly -->
+                        <include name="NAnt.MSNetTasks.dll" />
+                        <!-- include MS.NET specific test assembly -->
+                        <include name="NAnt.MSNet.Tests.dll" />
+                        <!-- include .NET 4.0 specific assemblies -->
+                        <include name="extensions/common/4.0/**/*.dll" />
+                        <!-- include .NET 4.5 specific assemblies -->
+                        <include name="extensions/common/4.5/**/*.dll" />
+                        <!-- include .NET 4.6 specific assemblies -->
+                        <include name="extensions/common/4.6/**/*.dll" />
+                    </task-assemblies>
+                    <tool-paths>
+                        <directory name="${sdkInstallRoot}"
+                            if="${property::exists('sdkInstallRoot')}" />
+                        <directory name="${installRoot}" />
+                    </tool-paths>
+                    <project>
+                        <readregistry
+                            property="installRoot"
+                            key="SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\InstallPath"
+                            hive="LocalMachine" />
+                        <locatesdk property="sdkInstallRoot" minwinsdkver="10.0" minnetfxver="4.0" maxnetfxver="4.0.99999" failonerror="false" />
+                    </project>
+                    <tasks>
+                        <task name="csc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportslangversion">true</attribute>
+                        </task>
+                        <task name="vbc">
+                            <attribute name="supportsdocgeneration">true</attribute>
+                            <attribute name="supportsnostdlib">true</attribute>
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                        </task>
+                        <task name="jsc">
+                            <attribute name="supportsplatform">true</attribute>
+                        </task>
+                        <task name="vjc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                        </task>
+                        <task name="resgen">
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                            <attribute name="supportsexternalfilereferences">true</attribute>
+                       </task>
+                        <task name="delay-sign">
+                            <attribute name="exename">sn</attribute>
+                        </task>
+                        <task name="license">
+                            <attribute name="exename">lc</attribute>
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                        </task>
+                    </tasks>
+                </framework>
+                <framework 
+                    name="net-4.7"
+                    family="net"
+                    version="4.7"
+                    description="Microsoft .NET Framework 4.7"
+                    sdkdirectory="${sdkInstallRoot}"
+                    frameworkdirectory="${installRoot}"
+                    frameworkassemblydirectory="${installRoot}"
+                    clrversion="4.0.30319"
+                    clrtype="Desktop"
+                    vendor="Microsoft"
+                    >
+                    <runtime>
+                        <probing-paths>
+                            <directory name="lib/common/2.0" />
+                            <directory name="lib/common/neutral" />
+                            <directory name="lib/common/4.0" />
+                            <directory name="lib/common/4.5" />
+                            <directory name="lib/common/4.6" />
+                            <directory name="lib/common/4.7" />
+                        </probing-paths>
+                        <modes>
+                            <strict>
+                                <environment>
+                                    <variable name="COMPLUS_VERSION" value="v4.7" />
+                                </environment>
+                            </strict>
+                        </modes>
+                    </runtime>
+                    <reference-assemblies basedir="${installRoot}">
+                        <include name="Accessibility.dll" />
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.Data.Entity.Build.Tasks.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.Transactions.Bridge.dll" />
+                        <include name="Microsoft.Transactions.Bridge.Dtc.dll" />
+                        <include name="Microsoft.VisualBasic.Activities.Compiler.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Configuration.Install.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtensions.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.Dynamic.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.ServiceMoniker40.dll" />
+                        <include name="System.ServiceModel.WasHosting.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xaml.Hosting.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <reference-assemblies basedir="${environment::get-folder-path('ProgramFiles')}/Reference Assemblies/Microsoft/Framework/.NETFramework/v4.7">
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Comptatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="PresentationBuildTasks.dll" />
+                        <include name="PresentationCore.dll" />
+                        <include name="PresentationFramework.Aero.dll" />
+                        <include name="PresentationFramework.Classic.dll" />
+                        <include name="PresentationFramework.Luna.dll" />
+                        <include name="PresentationFramework.Royale.dll" />
+                        <include name="ReachFramework.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract.dll" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtension.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.AccountManagement.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Printing.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Speech.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Windows.Input.Manipulations.dll" />
+                        <include name="System.Windows.Presentation.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <task-assemblies>
+                        <!-- include MS.NET version-neutral assemblies -->
+                        <include name="extensions/net/neutral/**/*.dll" />
+                        <!-- include MS.NET 4.0 specific assemblies -->
+                        <include name="extensions/net/4.0/**/*.dll" />
+                        <!-- include MS.NET 4.5 specific assemblies -->
+                        <include name="extensions/net/4.5/**/*.dll" />
+                        <!-- include MS.NET 4.6 specific assemblies -->
+                        <include name="extensions/net/4.6/**/*.dll" />
+                        <!-- include MS.NET 4.7 specific assemblies -->
+                        <include name="extensions/net/4.7/**/*.dll" />
+                        <!-- include MS.NET specific task assembly -->
+                        <include name="NAnt.MSNetTasks.dll" />
+                        <!-- include MS.NET specific test assembly -->
+                        <include name="NAnt.MSNet.Tests.dll" />
+                        <!-- include .NET 4.0 specific assemblies -->
+                        <include name="extensions/common/4.0/**/*.dll" />
+                        <!-- include .NET 4.5 specific assemblies -->
+                        <include name="extensions/common/4.5/**/*.dll" />
+                        <!-- include .NET 4.6 specific assemblies -->
+                        <include name="extensions/common/4.6/**/*.dll" />
+                        <!-- include .NET 4.7 specific assemblies -->
+                        <include name="extensions/common/4.7/**/*.dll" />
+                    </task-assemblies>
+                    <tool-paths>
+                        <directory name="${sdkInstallRoot}"
+                            if="${property::exists('sdkInstallRoot')}" />
+                        <directory name="${installRoot}" />
+                    </tool-paths>
+                    <project>
+                        <readregistry
+                            property="installRoot"
+                            key="SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\InstallPath"
+                            hive="LocalMachine" />
+                        <locatesdk property="sdkInstallRoot" minwinsdkver="10.0" minnetfxver="4.0" maxnetfxver="4.0.99999" failonerror="false" />
+                    </project>
+                    <tasks>
+                        <task name="csc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportslangversion">true</attribute>
+                        </task>
+                        <task name="vbc">
+                            <attribute name="supportsdocgeneration">true</attribute>
+                            <attribute name="supportsnostdlib">true</attribute>
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                        </task>
+                        <task name="jsc">
+                            <attribute name="supportsplatform">true</attribute>
+                        </task>
+                        <task name="vjc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                        </task>
+                        <task name="resgen">
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                            <attribute name="supportsexternalfilereferences">true</attribute>
+                       </task>
+                        <task name="delay-sign">
+                            <attribute name="exename">sn</attribute>
+                        </task>
+                        <task name="license">
+                            <attribute name="exename">lc</attribute>
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                        </task>
+                    </tasks>
+                </framework>
+                <framework 
+                    name="net-4.7.1"
+                    family="net"
+                    version="4.7.1"
+                    description="Microsoft .NET Framework 4.7.1"
+                    sdkdirectory="${sdkInstallRoot}"
+                    frameworkdirectory="${installRoot}"
+                    frameworkassemblydirectory="${installRoot}"
+                    clrversion="4.0.30319"
+                    clrtype="Desktop"
+                    vendor="Microsoft"
+                    >
+                    <runtime>
+                        <probing-paths>
+                            <directory name="lib/common/2.0" />
+                            <directory name="lib/common/neutral" />
+                            <directory name="lib/common/4.0" />
+                            <directory name="lib/common/4.5" />
+                            <directory name="lib/common/4.6" />
+                            <directory name="lib/common/4.7" />
+                        </probing-paths>
+                        <modes>
+                            <strict>
+                                <environment>
+                                    <variable name="COMPLUS_VERSION" value="v4.7.1" />
+                                </environment>
+                            </strict>
+                        </modes>
+                    </runtime>
+                    <reference-assemblies basedir="${installRoot}">
+                        <include name="Accessibility.dll" />
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.Data.Entity.Build.Tasks.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.Transactions.Bridge.dll" />
+                        <include name="Microsoft.Transactions.Bridge.Dtc.dll" />
+                        <include name="Microsoft.VisualBasic.Activities.Compiler.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Configuration.Install.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtensions.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.Dynamic.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.ServiceMoniker40.dll" />
+                        <include name="System.ServiceModel.WasHosting.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xaml.Hosting.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <reference-assemblies basedir="${environment::get-folder-path('ProgramFiles')}/Reference Assemblies/Microsoft/Framework/.NETFramework/v4.7.1">
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Comptatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="PresentationBuildTasks.dll" />
+                        <include name="PresentationCore.dll" />
+                        <include name="PresentationFramework.Aero.dll" />
+                        <include name="PresentationFramework.Classic.dll" />
+                        <include name="PresentationFramework.Luna.dll" />
+                        <include name="PresentationFramework.Royale.dll" />
+                        <include name="ReachFramework.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract.dll" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtension.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.AccountManagement.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Printing.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Speech.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Windows.Input.Manipulations.dll" />
+                        <include name="System.Windows.Presentation.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <task-assemblies>
+                        <!-- include MS.NET version-neutral assemblies -->
+                        <include name="extensions/net/neutral/**/*.dll" />
+                        <!-- include MS.NET 4.0 specific assemblies -->
+                        <include name="extensions/net/4.0/**/*.dll" />
+                        <!-- include MS.NET 4.5 specific assemblies -->
+                        <include name="extensions/net/4.5/**/*.dll" />
+                        <!-- include MS.NET 4.6 specific assemblies -->
+                        <include name="extensions/net/4.6/**/*.dll" />
+                        <!-- include MS.NET 4.7 specific assemblies -->
+                        <include name="extensions/net/4.7/**/*.dll" />
+                        <!-- include MS.NET specific task assembly -->
+                        <include name="NAnt.MSNetTasks.dll" />
+                        <!-- include MS.NET specific test assembly -->
+                        <include name="NAnt.MSNet.Tests.dll" />
+                        <!-- include .NET 4.0 specific assemblies -->
+                        <include name="extensions/common/4.0/**/*.dll" />
+                        <!-- include .NET 4.5 specific assemblies -->
+                        <include name="extensions/common/4.5/**/*.dll" />
+                        <!-- include .NET 4.6 specific assemblies -->
+                        <include name="extensions/common/4.6/**/*.dll" />
+                        <!-- include .NET 4.7 specific assemblies -->
+                        <include name="extensions/common/4.7/**/*.dll" />
+                    </task-assemblies>
+                    <tool-paths>
+                        <directory name="${sdkInstallRoot}"
+                            if="${property::exists('sdkInstallRoot')}" />
+                        <directory name="${installRoot}" />
+                    </tool-paths>
+                    <project>
+                        <readregistry
+                            property="installRoot"
+                            key="SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\InstallPath"
+                            hive="LocalMachine" />
+                        <locatesdk property="sdkInstallRoot" minwinsdkver="10.0" minnetfxver="4.0" maxnetfxver="4.0.99999" failonerror="false" />
+                    </project>
+                    <tasks>
+                        <task name="csc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportslangversion">true</attribute>
+                        </task>
+                        <task name="vbc">
+                            <attribute name="supportsdocgeneration">true</attribute>
+                            <attribute name="supportsnostdlib">true</attribute>
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                        </task>
+                        <task name="jsc">
+                            <attribute name="supportsplatform">true</attribute>
+                        </task>
+                        <task name="vjc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                        </task>
+                        <task name="resgen">
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                            <attribute name="supportsexternalfilereferences">true</attribute>
+                       </task>
+                        <task name="delay-sign">
+                            <attribute name="exename">sn</attribute>
+                        </task>
+                        <task name="license">
+                            <attribute name="exename">lc</attribute>
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                        </task>
+                    </tasks>
+                </framework>
+                <framework 
+                    name="net-4.7.2"
+                    family="net"
+                    version="4.7.2"
+                    description="Microsoft .NET Framework 4.7.2"
+                    sdkdirectory="${sdkInstallRoot}"
+                    frameworkdirectory="${installRoot}"
+                    frameworkassemblydirectory="${installRoot}"
+                    clrversion="4.0.30319"
+                    clrtype="Desktop"
+                    vendor="Microsoft"
+                    >
+                    <runtime>
+                        <probing-paths>
+                            <directory name="lib/common/2.0" />
+                            <directory name="lib/common/neutral" />
+                            <directory name="lib/common/4.0" />
+                            <directory name="lib/common/4.5" />
+                            <directory name="lib/common/4.6" />
+                            <directory name="lib/common/4.7" />
+                        </probing-paths>
+                        <modes>
+                            <strict>
+                                <environment>
+                                    <variable name="COMPLUS_VERSION" value="v4.7.2" />
+                                </environment>
+                            </strict>
+                        </modes>
+                    </runtime>
+                    <reference-assemblies basedir="${installRoot}">
+                        <include name="Accessibility.dll" />
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.Data.Entity.Build.Tasks.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.Transactions.Bridge.dll" />
+                        <include name="Microsoft.Transactions.Bridge.Dtc.dll" />
+                        <include name="Microsoft.VisualBasic.Activities.Compiler.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Configuration.Install.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtensions.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.Dynamic.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.ServiceMoniker40.dll" />
+                        <include name="System.ServiceModel.WasHosting.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xaml.Hosting.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <reference-assemblies basedir="${environment::get-folder-path('ProgramFiles')}/Reference Assemblies/Microsoft/Framework/.NETFramework/v4.7.2">
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Comptatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="PresentationBuildTasks.dll" />
+                        <include name="PresentationCore.dll" />
+                        <include name="PresentationFramework.Aero.dll" />
+                        <include name="PresentationFramework.Classic.dll" />
+                        <include name="PresentationFramework.Luna.dll" />
+                        <include name="PresentationFramework.Royale.dll" />
+                        <include name="ReachFramework.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract.dll" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtension.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.AccountManagement.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Printing.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Speech.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Windows.Input.Manipulations.dll" />
+                        <include name="System.Windows.Presentation.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <task-assemblies>
+                        <!-- include MS.NET version-neutral assemblies -->
+                        <include name="extensions/net/neutral/**/*.dll" />
+                        <!-- include MS.NET 4.0 specific assemblies -->
+                        <include name="extensions/net/4.0/**/*.dll" />
+                        <!-- include MS.NET 4.5 specific assemblies -->
+                        <include name="extensions/net/4.5/**/*.dll" />
+                        <!-- include MS.NET 4.6 specific assemblies -->
+                        <include name="extensions/net/4.6/**/*.dll" />
+                        <!-- include MS.NET 4.7 specific assemblies -->
+                        <include name="extensions/net/4.7/**/*.dll" />
+                        <!-- include MS.NET specific task assembly -->
+                        <include name="NAnt.MSNetTasks.dll" />
+                        <!-- include MS.NET specific test assembly -->
+                        <include name="NAnt.MSNet.Tests.dll" />
+                        <!-- include .NET 4.0 specific assemblies -->
+                        <include name="extensions/common/4.0/**/*.dll" />
+                        <!-- include .NET 4.5 specific assemblies -->
+                        <include name="extensions/common/4.5/**/*.dll" />
+                        <!-- include .NET 4.6 specific assemblies -->
+                        <include name="extensions/common/4.6/**/*.dll" />
+                        <!-- include .NET 4.7 specific assemblies -->
+                        <include name="extensions/common/4.7/**/*.dll" />
+                    </task-assemblies>
+                    <tool-paths>
+                        <directory name="${sdkInstallRoot}"
+                            if="${property::exists('sdkInstallRoot')}" />
+                        <directory name="${installRoot}" />
+                    </tool-paths>
+                    <project>
+                        <readregistry
+                            property="installRoot"
+                            key="SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\InstallPath"
+                            hive="LocalMachine" />
+                        <locatesdk property="sdkInstallRoot" minwinsdkver="10.0" minnetfxver="4.0" maxnetfxver="4.0.99999" failonerror="false" />
+                    </project>
+                    <tasks>
+                        <task name="csc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportslangversion">true</attribute>
+                        </task>
+                        <task name="vbc">
+                            <attribute name="supportsdocgeneration">true</attribute>
+                            <attribute name="supportsnostdlib">true</attribute>
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                        </task>
+                        <task name="jsc">
+                            <attribute name="supportsplatform">true</attribute>
+                        </task>
+                        <task name="vjc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                        </task>
+                        <task name="resgen">
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                            <attribute name="supportsexternalfilereferences">true</attribute>
+                       </task>
+                        <task name="delay-sign">
+                            <attribute name="exename">sn</attribute>
+                        </task>
+                        <task name="license">
+                            <attribute name="exename">lc</attribute>
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                        </task>
+                    </tasks>
+                </framework>
+                <framework 
+                    name="net-4.8"
+                    family="net"
+                    version="4.8"
+                    description="Microsoft .NET Framework 4.8"
+                    sdkdirectory="${sdkInstallRoot}"
+                    frameworkdirectory="${installRoot}"
+                    frameworkassemblydirectory="${installRoot}"
+                    clrversion="4.0.30319"
+                    clrtype="Desktop"
+                    vendor="Microsoft"
+                    >
+                    <runtime>
+                        <probing-paths>
+                            <directory name="lib/common/2.0" />
+                            <directory name="lib/common/neutral" />
+                            <directory name="lib/common/4.0" />
+                            <directory name="lib/common/4.5" />
+                            <directory name="lib/common/4.6" />
+                            <directory name="lib/common/4.7" />
+                            <directory name="lib/common/4.8" />
+                        </probing-paths>
+                        <modes>
+                            <strict>
+                                <environment>
+                                    <variable name="COMPLUS_VERSION" value="v4.8" />
+                                </environment>
+                            </strict>
+                        </modes>
+                    </runtime>
+                    <reference-assemblies basedir="${installRoot}">
+                        <include name="Accessibility.dll" />
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.Data.Entity.Build.Tasks.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.Transactions.Bridge.dll" />
+                        <include name="Microsoft.Transactions.Bridge.Dtc.dll" />
+                        <include name="Microsoft.VisualBasic.Activities.Compiler.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Configuration.Install.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtensions.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.Dynamic.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.ServiceMoniker40.dll" />
+                        <include name="System.ServiceModel.WasHosting.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xaml.Hosting.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <reference-assemblies basedir="${environment::get-folder-path('ProgramFiles')}/Reference Assemblies/Microsoft/Framework/.NETFramework/v4.8">
+                        <include name="Microsoft.Build.Conversion.v4.0.dll" />
+                        <include name="Microsoft.Build.dll" />
+                        <include name="Microsoft.Build.Engine.dll" />
+                        <include name="Microsoft.Build.Framework.dll" />
+                        <include name="Microsoft.Build.Tasks.v4.0.dll" />
+                        <include name="Microsoft.Build.Utilities.v4.0.dll" />
+                        <include name="Microsoft.CSharp.dll" />
+                        <include name="Microsoft.JScript.dll" />
+                        <include name="Microsoft.VisualBasic.Compatibility.Data.dll" />
+                        <include name="Microsoft.VisualBasic.Comptatibility.dll" />
+                        <include name="Microsoft.VisualBasic.dll" />
+                        <include name="Microsoft.VisualC.dll" />
+                        <include name="Microsoft.VisualC.STLCLR.dll" />
+                        <include name="mscorlib.dll" />
+                        <include name="PresentationBuildTasks.dll" />
+                        <include name="PresentationCore.dll" />
+                        <include name="PresentationFramework.Aero.dll" />
+                        <include name="PresentationFramework.Classic.dll" />
+                        <include name="PresentationFramework.Luna.dll" />
+                        <include name="PresentationFramework.Royale.dll" />
+                        <include name="ReachFramework.dll" />
+                        <include name="System.Activities.Core.Presentation.dll" />
+                        <include name="System.Activities.dll" />
+                        <include name="System.Activities.DurableInstancing.dll" />
+                        <include name="System.Activities.Presentation.dll" />
+                        <include name="System.AddIn.Contract.dll" />
+                        <include name="System.AddIn.dll" />
+                        <include name="System.ComponentModel.Composition.dll" />
+                        <include name="System.ComponentModel.DataAnnotations.dll" />
+                        <include name="System.Configuration.dll" />
+                        <include name="System.Core.dll" />
+                        <include name="System.Data.DataSetExtension.dll" />
+                        <include name="System.Data.dll" />
+                        <include name="System.Data.Entity.Design.dll" />
+                        <include name="System.Data.Entity.dll" />
+                        <include name="System.Data.Linq.dll" />
+                        <include name="System.Data.OracleClient.dll" />
+                        <include name="System.Data.Services.Client.dll" />
+                        <include name="System.Data.Services.Design.dll" />
+                        <include name="System.Data.Services.dll" />
+                        <include name="System.Data.SqlXml.dll" />
+                        <include name="System.Deployment.dll" />
+                        <include name="System.Design.dll" />
+                        <include name="System.Device.dll" />
+                        <include name="System.DirectoryServices.AccountManagement.dll" />
+                        <include name="System.DirectoryServices.dll" />
+                        <include name="System.DirectoryServices.Protocols.dll" />
+                        <include name="System.dll" />
+                        <include name="System.Drawing.Design.dll" />
+                        <include name="System.Drawing.dll" />
+                        <include name="System.EnterpriseServices.dll" />
+                        <include name="System.EnterpriseServices.Thunk.dll" />
+                        <include name="System.EnterpriseServices.Wrapper.dll" />
+                        <include name="System.IdentityModel.dll" />
+                        <include name="System.IdentityModel.Selectors.dll" />
+                        <include name="System.IO.Log.dll" />
+                        <include name="System.Management.dll" />
+                        <include name="System.Management.Instrumentation.dll" />
+                        <include name="System.Messaging.dll" />
+                        <include name="System.Net.dll" />
+                        <include name="System.Numerics.dll" />
+                        <include name="System.Printing.dll" />
+                        <include name="System.Runtime.Caching.dll" />
+                        <include name="System.Runtime.DurableInstancing.dll" />
+                        <include name="System.Runtime.Remoting.dll" />
+                        <include name="System.Runtime.Serialization.dll" />
+                        <include name="System.Runtime.Serialization.Formatters.Soap.dll" />
+                        <include name="System.Security.dll" />
+                        <include name="System.ServiceModel.Activation.dll" />
+                        <include name="System.ServiceModel.Activities.dll" />
+                        <include name="System.ServiceModel.Channels.dll" />
+                        <include name="System.ServiceModel.Discovery.dll" />
+                        <include name="System.ServiceModel.dll" />
+                        <include name="System.ServiceModel.Routing.dll" />
+                        <include name="System.ServiceModel.Web.dll" />
+                        <include name="System.ServiceProcess.dll" />
+                        <include name="System.Speech.dll" />
+                        <include name="System.Transactions.dll" />
+                        <include name="System.Web.Abstractions.dll" />
+                        <include name="System.Web.ApplicationServices.dll" />
+                        <include name="System.Web.DataVisualization.Design.dll" />
+                        <include name="System.Web.DataVisualization.dll" />
+                        <include name="System.Web.dll" />
+                        <include name="System.Web.DynamicData.Design.dll" />
+                        <include name="System.Web.DynamicData.dll" />
+                        <include name="System.Web.Entity.Design.dll" />
+                        <include name="System.Web.Entity.dll" />
+                        <include name="System.Web.Extensions.Design.dll" />
+                        <include name="System.Web.Extensions.dll" />
+                        <include name="System.Web.Mobile.dll" />
+                        <include name="System.Web.RegularExpressions.dll" />
+                        <include name="System.Web.Routing.dll" />
+                        <include name="System.Web.Services.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.Design.dll" />
+                        <include name="System.Windows.Forms.DataVisualization.dll" />
+                        <include name="System.Windows.Forms.dll" />
+                        <include name="System.Windows.Input.Manipulations.dll" />
+                        <include name="System.Windows.Presentation.dll" />
+                        <include name="System.Workflow.Activities.dll" />
+                        <include name="System.Workflow.ComponentModel.dll" />
+                        <include name="System.Workflow.Runtime.dll" />
+                        <include name="System.WorkflowServices.dll" />
+                        <include name="System.Xaml.dll" />
+                        <include name="System.Xml.dll" />
+                        <include name="System.Xml.Linq.dll" />
+                    </reference-assemblies>
+                    <task-assemblies>
+                        <!-- include MS.NET version-neutral assemblies -->
+                        <include name="extensions/net/neutral/**/*.dll" />
+                        <!-- include MS.NET 4.0 specific assemblies -->
+                        <include name="extensions/net/4.0/**/*.dll" />
+                        <!-- include MS.NET 4.5 specific assemblies -->
+                        <include name="extensions/net/4.5/**/*.dll" />
+                        <!-- include MS.NET 4.6 specific assemblies -->
+                        <include name="extensions/net/4.6/**/*.dll" />
+                        <!-- include MS.NET 4.7 specific assemblies -->
+                        <include name="extensions/net/4.7/**/*.dll" />
+                        <!-- include MS.NET 4.8 specific assemblies -->
+                        <include name="extensions/net/4.8/**/*.dll" />
+                        <!-- include MS.NET specific task assembly -->
+                        <include name="NAnt.MSNetTasks.dll" />
+                        <!-- include MS.NET specific test assembly -->
+                        <include name="NAnt.MSNet.Tests.dll" />
+                        <!-- include .NET 4.0 specific assemblies -->
+                        <include name="extensions/common/4.0/**/*.dll" />
+                        <!-- include .NET 4.5 specific assemblies -->
+                        <include name="extensions/common/4.5/**/*.dll" />
+                        <!-- include .NET 4.6 specific assemblies -->
+                        <include name="extensions/common/4.6/**/*.dll" />
+                        <!-- include .NET 4.7 specific assemblies -->
+                        <include name="extensions/common/4.7/**/*.dll" />
+                        <!-- include .NET 4.8 specific assemblies -->
+                        <include name="extensions/common/4.8/**/*.dll" />
+                    </task-assemblies>
+                    <tool-paths>
+                        <directory name="${sdkInstallRoot}"
+                            if="${property::exists('sdkInstallRoot')}" />
+                        <directory name="${installRoot}" />
+                    </tool-paths>
+                    <project>
+                        <readregistry
+                            property="installRoot"
+                            key="SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\InstallPath"
+                            hive="LocalMachine" />
+                        <locatesdk property="sdkInstallRoot" minwinsdkver="10.0" minnetfxver="4.0" maxnetfxver="4.0.99999" failonerror="false" />
+                    </project>
+                    <tasks>
+                        <task name="csc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportslangversion">true</attribute>
+                        </task>
+                        <task name="vbc">
+                            <attribute name="supportsdocgeneration">true</attribute>
+                            <attribute name="supportsnostdlib">true</attribute>
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportsplatform">true</attribute>
+                            <attribute name="supportswarnaserrorlist">true</attribute>
+                        </task>
+                        <task name="jsc">
+                            <attribute name="supportsplatform">true</attribute>
+                        </task>
+                        <task name="vjc">
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                        </task>
+                        <task name="resgen">
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                            <attribute name="supportsexternalfilereferences">true</attribute>
+                       </task>
+                        <task name="delay-sign">
+                            <attribute name="exename">sn</attribute>
+                        </task>
+                        <task name="license">
+                            <attribute name="exename">lc</attribute>
+                            <attribute name="supportsassemblyreferences">true</attribute>
+                        </task>
+                    </tasks>
+                </framework>
+                <!-- deprecated -->
                 <framework
                     name="netcf-1.0"
                     family="netcf"
@@ -1294,6 +4213,7 @@
                         </task>
                     </tasks>
                 </framework>
+                <!-- deprecated -->
                 <framework 
                     name="netcf-2.0"
                     family="netcf"
@@ -1375,6 +4295,7 @@
                         </task>
                     </tasks>
                 </framework>
+                <!-- deprecated -->
                 <framework 
                     name="silverlight-2.0"
                     family="silverlight"
@@ -1483,6 +4404,7 @@
                         </task>
                     </tasks>
                 </framework>
+                <!-- deprecated -->
                 <framework
                     name="silverlight-3.0"
                     family="silverlight"
@@ -1599,6 +4521,7 @@
                         </task>
                     </tasks>
                 </framework>
+                <!-- deprecated -->
                 <framework
                     name="silverlight-4.0"
                     family="silverlight"
@@ -1714,6 +4637,7 @@
                         </task>
                     </tasks>
                 </framework>
+                <!-- deprecated -->
                 <framework
                     name="silverlight-5.0"
                     family="silverlight"
@@ -1834,6 +4758,7 @@
                         </task>
                     </tasks>
                 </framework>
+                <!-- deprecated -->
                 <framework
                     name="mono-1.0"
                     family="mono"
@@ -2017,6 +4942,7 @@
                         </task>
                     </tasks>
                 </framework>
+                <!-- deprecated -->
                 <framework 
                     name="mono-2.0"
                     family="mono"
@@ -2537,6 +5463,7 @@
                         </task>
                     </tasks>
                 </framework>
+                <!-- deprecated -->
                 <framework
                     name="moonlight-2.0" 
                     family="moonlight"
@@ -2673,6 +5600,7 @@
                         </task>
                     </tasks>
                 </framework>
+                <!-- deprecated -->
                 <framework 
                     name="sscli-1.0"
                     family="sscli"
@@ -2742,6 +5670,7 @@
                         <!-- exclude win32 specific test assembly -->
                         <exclude name="NAnt.Win32.Tests.dll" />
                 </task-assemblies>
+                <!-- deprecated -->
                 <framework 
                     name="mono-1.0"
                     family="mono"
@@ -2843,6 +5772,7 @@
                         </task>
                     </tasks>
                 </framework>
+                <!-- deprecated -->
                 <framework
                     name="mono-2.0"
                     family="mono"
@@ -3308,6 +6238,7 @@
                         </task>
                     </tasks>
                 </framework>
+                <!-- deprecated -->
                 <framework
                     name="moonlight-2.0" 
                     family="moonlight" 


### PR DESCRIPTION
- added support for .NET framework 4.5, 4.5.1, 4.5.2, 4.6, 4.6.1, 4.6.2, 4.7, 4.7.1, 4.7.2 and 4.8
- deprecated framework targets: net-1.0, net-1.1, net-2.0, netcf-1.0, netcf-2.0, silverlight-2.0, silverlight-3.0, silverlight-4.0, silverlight-5.0, mono-1.0, mono-2.0, moonlight-2.0, sscli-1.0,

Fixes #55 